### PR TITLE
Add Homebrew installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Download the latest version from [GitHub Releases](https://github.com/syi0808/sc
 
 Open the `.dmg` file and drag Screenize into the Applications folder.
 
+**Homebrew**
+
+```bash
+brew install --cask thedavidweng/tap/screenize
+```
+
 > **macOS Gatekeeper warning:** Screenize is not notarized with Apple, so macOS may display a warning when you first open the app. To open it:
 >
 > 1. Right-click (or Control-click) the Screenize app in the Applications folder


### PR DESCRIPTION
Added Homebrew installation instructions for Screenize.

## Summary

Add Homebrew installation instructions

## Related Issues

#3 

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring (no functional changes)
- [x] Documentation update
- [ ] Other

## Checklist

- [x] The project builds successfully (`Cmd+B`)
- [x] No SwiftLint warnings (`./scripts/lint.sh`)
- [x] New code follows existing conventions
- [x] Relevant documentation has been updated if needed

## Screenshots / Screen Recordings

<!-- If there are UI changes, attach screenshots or screen recordings. -->

## Additional Context

<!-- Any extra context reviewers should know about. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Homebrew cask installation instructions to the README. Users can now install and manage the application using Homebrew, providing a convenient alternative installation method for macOS users who prefer package managers. This offers a standardized package management approach alongside existing installation options, making the application more accessible to the broader developer community.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->